### PR TITLE
Fixed issue with navigation not working on some about pages

### DIFF
--- a/public/js/navbar-scroll.js
+++ b/public/js/navbar-scroll.js
@@ -1,21 +1,10 @@
 $(document).ready(function() {
-  // logic that handles navbar backgorund color when scrolling down
-  $(window).scroll(function() {
-    if ($(document).scrollTop() > 75) {
-      $('.myNavbar').css('background-color', 'rgb(221, 128, 100)')
-      $('.myNavbar li a').css('color', 'white')
-    } else {
-      $('.myNavbar').css('background-color', 'rgb(221, 128, 100)')
-      $('.myNavbar li a').css('color', 'white')
-    }
-  })
-
   // logic for smooth scrolling animation after tab is clicked
-  $('.myNavbar a, .mobile-nav-list a').click(function(e) {
-    if (this.hash !== '') {
+  $(".myNavbar a, .mobile-nav-list a").click(function(e) {
+    if (this.hash !== "") {
       e.preventDefault()
       let hash = this.hash
-      $('html, body').animate({ scrollTop: $(hash).offset().top }, 400, () => {
+      $("html, body").animate({ scrollTop: $(hash).offset().top }, 400, () => {
         window.location.hash = hash
       })
     }

--- a/views/history.hbs
+++ b/views/history.hbs
@@ -18,9 +18,6 @@
     <!-- STYLESHEETS -->
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="/css/history.css">
-
-    <!-- SCRIPTS -->
-    <script src='/js/navbar-scroll.js'></script>
 </head>
 <body class='background-light-red'>
 

--- a/views/venue.hbs
+++ b/views/venue.hbs
@@ -18,9 +18,6 @@
     <!-- STYLESHEETS -->
     <link rel='stylesheet' type='text/css' href='/css/style.css' />
     <link rel="stylesheet" type="text/css" href="/css/venue.css">
-
-    <!-- SCRIPTS -->
-    <script src='/js/navbar-scroll.js'></script>
 </head>
 <body data-spy="scroll" data-target=".navbar" data-offset="50">
 


### PR DESCRIPTION
Addresses feedback that targeted navigation links not working when you were on Venue and History pages. Example: Being on the venue page and not being able to go to `/#schedule` or `/#faq`

The issue was not a back end issue. Looks like `navbar-scroll.js` was included in Venue and History pages when it was not supposed to be. The team page was only working because it did not include `navbar-scroll.js`. The root of this problem is probably because someone copy pasted HTML from index.hbs instead of starting from scratch :)

The fix was just to remove `navbar-scroll.js` from venue and history pages.