### PR TITLE
Dashboard Team Parts

### DIFF
--- a/ideahacks/routes/dashboard/dashboard.js
+++ b/ideahacks/routes/dashboard/dashboard.js
@@ -1,6 +1,7 @@
 const bcrypt = require("bcrypt-nodejs")
 
 const Part = require("../../db").Part
+const { Team } = require("../../db")
 
 const getParts = (req, res) => {
 	Part.find().then(parts => {
@@ -47,8 +48,15 @@ const postMe = (req, res) => {
 	})
 }
 
+const getTeams = (req, res) => {
+	Team.find().then(teams => {
+		res.render("dashboard-team-parts", { teams })
+	})
+}
+
 module.exports = {
 	getParts,
 	getMe,
-	postMe
+	postMe,
+	getTeams
 }

--- a/ideahacks/routes/dashboard/index.js
+++ b/ideahacks/routes/dashboard/index.js
@@ -13,6 +13,8 @@ dashboardRouter.get("/", setResLocals, h.isVerified, dashboardHandlers.getMe)
 
 dashboardRouter.get("/parts", setResLocals, h.isVerified, dashboardHandlers.getParts)
 
+dashboardRouter.get("/teams", setResLocals, h.isVerified, dashboardHandlers.getTeams)
+
 dashboardRouter.get("/me", setResLocals, h.isVerified, dashboardHandlers.getMe)
 dashboardRouter.post("/me", setResLocals, h.isVerified, dashboardHandlers.postMe)
 

--- a/views/dashboard-team-parts.hbs
+++ b/views/dashboard-team-parts.hbs
@@ -1,0 +1,56 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title>Teams - Dashboard</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- jQuery -->
+    <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js'></script>
+
+    <!-- BOOTSTRAP -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+    <!-- GOOGLE FONTS -->
+    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600i,700" rel="stylesheet">
+
+    <!-- STYLESHEETS -->
+    <link rel='stylesheet' type='text/css' href='/css/style.css' />
+    <link rel='stylesheet' type='text/css' href='/css/admin-teams.css' />
+</head>
+<body>
+
+    <div class='wrapper'>
+        <!-- NAVBAR -->
+        {{> navbar }}
+
+        <div class='banner'>
+            <h1>TEAM PARTS</h1>
+            <p>View what parts each team has checked out here!</p>
+            <p class='filter-description'>(You can filter by team number or part name)</p>
+            {{> filter }}
+        </div>
+
+
+        <div class='text-center container-fluid'>
+            <ul class='filter-list'>
+                {{#each teams}}
+                    <div class='col-md-3'>
+                        <div class='team'>
+                            <h1 class='team-number text-center filter-key'>Team {{ this.teamNumber }}</h1>
+                            <div class='container-fluid parts-list'>
+                                {{#each this.parts }}
+                                    <p class='text-center part-name filter-key'>{{ this }}</p>
+                                {{/each}}
+                            </div>
+                        </div>
+                    </div>
+                {{/each}}
+            </ul>
+        </div>
+
+    </div>
+
+</body>
+</html>

--- a/views/partials/navbar.hbs
+++ b/views/partials/navbar.hbs
@@ -32,6 +32,9 @@
             <!-- APPS ARE CLOSED -->
             <!-- <li class='dashboard'><a href='/dashboard/application'>Application</a></li> -->
 
+            <!-- TEAMS -->
+            <li class='dashboard'><a href='/dashboard/teams'>Teams</a></li>
+
             <!-- PARTS LIST -->
             <li class='dashboard'><a href='/dashboard/parts'>Parts List</a></li>
 
@@ -66,6 +69,9 @@
 
             <!-- APPS ARE CLOSED -->
             <!-- <li><a href='/dashboard/application'>Application</a></li> -->
+
+            <!-- TEAMS -->
+            <li><a href='/dashboard/teams'>Teams</a></li>
 
             <!-- PARTS LIST -->
             <li><a href='/dashboard/parts'>Parts List</a></li>


### PR DESCRIPTION
1. New dashboard endpoints to serve the new duplicate page
2. Edited navbar so that "Teams" tab shows up in the navbar 
3. Copy paste the admin page into a duplicate dashboard page