### PR TITLE
Add privacy policy

### DIFF
--- a/ideahacks/routes/main/index.js
+++ b/ideahacks/routes/main/index.js
@@ -11,6 +11,8 @@ mainRouter.get("/team", setResLocals, staticHandlers.getTeam)
 
 mainRouter.get("/history", setResLocals, staticHandlers.getHistory)
 
+mainRouter.get("/privacy", setResLocals, staticHandlers.getPrivacy)
+
 mainRouter.get("/login", setResLocals, authHandlers.getLogin)
 mainRouter.post("/login", authHandlers.postLogin)
 mainRouter.post("/login/recoverPassword/:email", authHandlers.recoverPassword)
@@ -27,5 +29,6 @@ mainRouter.post("/confirm", h.isAuthenticated, authHandlers.postConfirm)
 mainRouter.get("/verify/:hash", authHandlers.getVerify)
 
 mainRouter.get("/logout", authHandlers.getLogout)
+
 
 module.exports = mainRouter

--- a/ideahacks/routes/main/index.js
+++ b/ideahacks/routes/main/index.js
@@ -30,5 +30,4 @@ mainRouter.get("/verify/:hash", authHandlers.getVerify)
 
 mainRouter.get("/logout", authHandlers.getLogout)
 
-
 module.exports = mainRouter

--- a/ideahacks/routes/main/static.js
+++ b/ideahacks/routes/main/static.js
@@ -17,9 +17,14 @@ const getConfirm = (req, res) => {
 	return res.render("confirm")
 }
 
+const getPrivacy = (req, res) => {
+	return res.render("privacy")
+}
+
 module.exports = {
 	getMain,
 	getTeam,
 	getHistory,
-	getConfirm
+	getConfirm,
+	getPrivacy
 }

--- a/public/css/privacy.css
+++ b/public/css/privacy.css
@@ -43,7 +43,7 @@ h1 {
 }
 
 @media (max-width: 500px) {
-    .background {
-        margin-top: 100px;
-    }
+	.background {
+		margin-top: 100px;
+	}
 }

--- a/public/css/privacy.css
+++ b/public/css/privacy.css
@@ -10,22 +10,22 @@
 }
 
 .text-box {
-    background-color: white;
-    padding: 20px;
-    max-height: 60vh;
-    overflow-y: auto;
+	background-color: white;
+	padding: 20px;
+	max-height: 60vh;
+	overflow-y: auto;
 
-    border-radius: 10px;
+	border-radius: 10px;
 }
 
 h1 {
-    font-family: "Source Code Pro", monospace;
-    margin: 0 0 20px;
+	font-family: "Source Code Pro", monospace;
+	margin: 0 0 20px;
 }
 
 .text-box p {
-    text-align: left;
-    margin: 0;
+	text-align: left;
+	margin: 0;
 }
 
 .text-box a,

--- a/public/css/privacy.css
+++ b/public/css/privacy.css
@@ -41,3 +41,9 @@ h1 {
 	color: #e1489a;
 	cursor: pointer;
 }
+
+@media (max-width: 500px) {
+    .background {
+        margin-top: 100px;
+    }
+}

--- a/public/css/privacy.css
+++ b/public/css/privacy.css
@@ -1,0 +1,43 @@
+.background {
+	margin-top: 160px;
+	padding: 20px;
+
+	border-radius: 10px;
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	text-align: center;
+}
+
+.text-box {
+    background-color: white;
+    padding: 20px;
+    max-height: 60vh;
+    overflow-y: auto;
+
+    border-radius: 10px;
+}
+
+h1 {
+    font-family: "Source Code Pro", monospace;
+    margin: 0 0 20px;
+}
+
+.text-box p {
+    text-align: left;
+    margin: 0;
+}
+
+.text-box a,
+.text-box a:active {
+	text-decoration: none;
+	color: #50b5dd;
+	font-size: 14px;
+	line-height: inherit;
+}
+
+.text-box a:hover {
+	text-decoration: underline;
+	color: #e1489a;
+	cursor: pointer;
+}

--- a/views/privacy.hbs
+++ b/views/privacy.hbs
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Privacy Policy - IDEA Hacks</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- jQuery -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+
+    <!-- Bootstrap -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+    <!-- Google Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Roboto&family=Source+Code+Pro&display=swap" rel="stylesheet">
+
+    <!-- STYLESHEETS -->
+    <link rel='stylesheet' type='text/css' href='/css/style.css' />
+    <link rel="stylesheet" type='text/css' href="/css/privacy.css">
+</head>
+<body>
+    
+    <div class="wrapper">
+        <!-- NAVBAR -->
+        {{> navbar }}
+
+        <div class="houseline"></div>
+
+        <div class="background theme-yellow col-lg-6 col-lg-offset-3 col-md-8 col-md-offset-2 col-xs-10 col-xs-offset-1">
+            <h1>privacy policy</h1>
+            <div class="text-box">
+                <p>
+                    When you log in with Google, the only information we take is your email. 
+                    We also request access to your profile so that, in the future, we can use that 
+                    information to help fill out your application for you. This isn't implemented yet, 
+                    so although we request it, we don't touch your profile information.
+                    <br><br>
+                    We use your email purely for identifying your account and contacting you. We do not
+                    share your email or other information with anyone outside of the IDEA Hacks organization.
+                    If an occasion comes up where we would need to share some of your information (i.e.: a 
+                    resume book for sponsors), we will get your consent before sharing it.
+                    <br><br>
+                    If you would like to verify what information we collect from your Google profile, 
+                    check out our source code <a href="https://github.com/ideahacks/ideahacks.la/blob/development/ideahacks/auth/index.js">here</a>.
+                </p>
+            </div>
+        </div>
+    </div>
+
+</body>
+</html>

--- a/views/privacy.hbs
+++ b/views/privacy.hbs
@@ -20,7 +20,7 @@
     <link rel="stylesheet" type='text/css' href="/css/privacy.css">
 </head>
 <body>
-    
+
     <div class="wrapper">
         <!-- NAVBAR -->
         {{> navbar }}
@@ -31,17 +31,17 @@
             <h1>privacy policy</h1>
             <div class="text-box">
                 <p>
-                    When you log in with Google, the only information we take is your email. 
-                    We also request access to your profile so that, in the future, we can use that 
-                    information to help fill out your application for you. This isn't implemented yet, 
+                    When you log in with Google, the only information we take is your email.
+                    We also request access to your profile so that, in the future, we can use that
+                    information to help fill out your application for you. This isn't implemented yet,
                     so although we request it, we don't touch your profile information.
                     <br><br>
                     We use your email purely for identifying your account and contacting you. We do not
                     share your email or other information with anyone outside of the IDEA Hacks organization.
-                    If an occasion comes up where we would need to share some of your information (i.e.: a 
+                    If an occasion comes up where we would need to share some of your information (i.e.: a
                     resume book for sponsors), we will get your consent before sharing it.
                     <br><br>
-                    If you would like to verify what information we collect from your Google profile, 
+                    If you would like to verify what information we collect from your Google profile,
                     check out our source code <a href="https://github.com/ideahacks/ideahacks.la/blob/development/ideahacks/auth/index.js">here</a>.
                 </p>
             </div>

--- a/views/privacy.hbs
+++ b/views/privacy.hbs
@@ -38,7 +38,7 @@
                     <br><br>
                     We use your email purely for identifying your account and contacting you. We do not
                     share your email or other information with anyone outside of the IDEA Hacks organization.
-                    If an occasion comes up where we would need to share some of your information (i.e.: a
+                    If an occasion comes up where we would need to share some of your information (e.g., a
                     resume book for sponsors), we will get your consent before sharing it.
                     <br><br>
                     If you would like to verify what information we collect from your Google profile,


### PR DESCRIPTION
This adds a brief privacy policy at the `/privacy` route. This was only added because the Google consent screen needs a link to a privacy policy to be verified.

Currently, there are no visible links on the website to the privacy policy; it's only linked on the consent screen when logging in with Google.