### PR TITLE
Increase border radius on modals and several application review objects to 10px

### DIFF
--- a/public/css/admin-application-review.css
+++ b/public/css/admin-application-review.css
@@ -48,6 +48,7 @@ input {
 	width: 215px;
 	height: 125px;
 	margin: 10px;
+	border-radius: 10px;
 }
 
 .stats-box h1 {
@@ -76,6 +77,7 @@ input {
 	color: white;
 	font-size: 17px;
 	font-family: "Roboto Condensed";
+	border-radius: 10px;
 }
 
 .application:hover {

--- a/public/css/modal.css
+++ b/public/css/modal.css
@@ -22,7 +22,7 @@
 	margin: 160px auto;
 	padding: 30px 20px 30px 0px;
 	border: 1px solid #888;
-	border-radius: 0;
+	border-radius: 10px;
 	width: 80%;
 }
 


### PR DESCRIPTION
For the following classes, updated css to increase border radius to 10px:
- modal-content (public/css/modal.css)
- stats-box (public/css/admin-application-review.css)
- application (public/css/admin-application-review.css)

The modal-content class applies to the modal for reviewing applications, as well as the modals for team formation and parts. I assumed from Figma that we would want to have this increased border radius applied consistently across modals, let me know if this is not the case.

The stats-box class refers to the objects indicating the number of applications pending, accepted, waitlisted, etc. The application class refers to each object listed on the page representing an application.