### PR TITLE
Improve db consistency on team creation page

### DIFF
--- a/public/css/admin-team-creation.css
+++ b/public/css/admin-team-creation.css
@@ -24,14 +24,19 @@ textarea:focus {
 	box-shadow: none;
 }
 
-#team-input,
-#users-input {
+#team-number,
+#members,
+#confirm {
 	max-width: 400px;
 	margin: auto;
 	background-color: var(--white);
 	color: var(--black);
 	padding: 20px;
 	border-radius: 20px;
+}
+
+#with-team {
+	font-weight: bold;
 }
 
 .header {

--- a/public/js/admin-team-creation.js
+++ b/public/js/admin-team-creation.js
@@ -88,14 +88,14 @@ $(() => {
 			for (let i = 0; i < oldTeammateResponses.length; i++) {
 				let userEmail = withTeam[i]
 				let oldMembers = oldTeammateResponses[i][0].split(", ")
+				console.log(oldMembers)
 				let userIndex = oldMembers.indexOf(userEmail)
-				let oldTeammate
+				let oldTeammates
 				if (userIndex > -1) {
-					oldTeammates = oldMembers.splice(userIndex, 1)
+					oldMembers.splice(userIndex, 1)
 				}
-				else {
-					oldTeammates = oldMembers
-				}
+				oldTeammates = oldMembers
+
 				// Get the old teammate's data and prepare to remove the user
 				// from their teammate list
 				oldTeammates.forEach(teammate => {

--- a/public/js/admin-team-creation.js
+++ b/public/js/admin-team-creation.js
@@ -99,28 +99,32 @@ $(() => {
 				// Get the old teammate's data and prepare to remove the user
 				// from their teammate list
 				oldTeammates.forEach(teammate => {
-					$.get("/api/users/" + teammate).then(teammateData => {
-						let toRemove = teammateData.teammates.indexOf(userEmail)
-						if (toRemove > -1) {
-							teammateData.teammates = teammateData.teammates.splice(toRemove, 1)
-						}
-						teammateUpdatePromises.push($.ajax({
-							url: "/api/users/" + teammateData.email, 
-							type: "PUT", 
-							data: teammateData
-						}))
-					})
-					.catch(err => errorHandler(err))
+					$.get("/api/users/" + teammate)
+						.then(teammateData => {
+							let toRemove = teammateData.teammates.indexOf(userEmail)
+							if (toRemove > -1) {
+								teammateData.teammates = teammateData.teammates.splice(toRemove, 1)
+							}
+							teammateUpdatePromises.push(
+								$.ajax({
+									url: "/api/users/" + teammateData.email,
+									type: "PUT",
+									data: teammateData
+								})
+							)
+						})
+						.catch(err => errorHandler(err))
 				})
 			}
 
-			$.when(...teammateUpdatePromises).then(function(...updateResponses) {
-				// At this point, all references to any of the users being in
-				// their old teams have been removed, so we're clear to create
-				// the new team
-				return createTeam()
-			})
-			.catch(err => errorHandler(err))
+			$.when(...teammateUpdatePromises)
+				.then(function(...updateResponses) {
+					// At this point, all references to any of the users being in
+					// their old teams have been removed, so we're clear to create
+					// the new team
+					return createTeam()
+				})
+				.catch(err => errorHandler(err))
 		})
 	})
 })

--- a/public/js/admin-team-creation.js
+++ b/public/js/admin-team-creation.js
@@ -26,25 +26,27 @@ $(() => {
 		// Global var to store updated members
 		members = []
 		memberEmails.forEach(email => {
-			$.get("/api/users/" + email).then(member => {
-				// If the user has a team, save them for confirmation
-				if (member.hasTeam) {
-					withTeam.push(email)
-				}
-				
-				member.hasTeam = true
-				member.teamNumber = teamNumber
-				member.teammates = []
-				memberEmails.forEach(e => {
-					if (e !== email) {
-						member.teammates.push(e)
+			$.get("/api/users/" + email)
+				.then(member => {
+					// If the user has a team, save them for confirmation
+					if (member.hasTeam) {
+						withTeam.push(email)
 					}
+
+					member.hasTeam = true
+					member.teamNumber = teamNumber
+					member.teammates = []
+					memberEmails.forEach(e => {
+						if (e !== email) {
+							member.teammates.push(e)
+						}
+					})
+					members.push(member)
 				})
-				members.push(member)
-			}).catch(err => {
-				//Email doesn't exist
-				errorHandler(email + " is not a user!")
-			})
+				.catch(err => {
+					//Email doesn't exist
+					errorHandler(email + " is not a user!")
+				})
 		})
 
 		if (withTeam.length > 0) {
@@ -72,11 +74,11 @@ function createTeam() {
 		})
 
 	members.forEach(member => {
-		$.ajax({ url: "/api/users" + member.email, type: "PUT", data: member}).catch(err => {
+		$.ajax({ url: "/api/users" + member.email, type: "PUT", data: member }).catch(err => {
 			errorHandler(err)
 		})
 	})
-	
+
 	return successHandler()
 }
 

--- a/public/js/admin-team-creation.js
+++ b/public/js/admin-team-creation.js
@@ -32,7 +32,6 @@ $(() => {
 
 		members = []
 		let withTeam = []
-		console.log(memberPromises)
 		$.when(...memberPromises)
 			.done(function(...memberResponses) {
 				memberResponses.forEach(memberRes => {
@@ -53,7 +52,6 @@ $(() => {
 					members.push(member)
 				})
 
-				console.log(withTeam)
 				if (withTeam.length > 0) {
 					$("#members").hide()
 					$("#with-team").html(withTeam.join(", "))

--- a/public/js/admin-team-creation.js
+++ b/public/js/admin-team-creation.js
@@ -25,7 +25,7 @@ $(() => {
 			.val()
 			.split("\n")
 		
-		memberPromises = []
+		let memberPromises = []
 		memberEmails.forEach(email => {
 			memberPromises.push($.get("/api/users/" + email))
 		})

--- a/public/js/admin-team-creation.js
+++ b/public/js/admin-team-creation.js
@@ -32,10 +32,12 @@ $(() => {
 
 		members = []
 		let withTeam = []
+		let curEmail = ""
 		$.when(...memberPromises)
-			.done(function(...memberResponses) {
-				memberResponses.forEach(memberRes => {
-					member = memberRes[0]
+			.then(function(...memberResponses) {
+				for (let i = 0; i < memberResponses.length; i++) {
+					member = memberResponses[i][0]
+					curEmail = memberEmails[i]
 					// If the user has a team, save them for confirmation
 					if (member.hasTeam) {
 						withTeam.push(member.email)
@@ -50,7 +52,7 @@ $(() => {
 						}
 					})
 					members.push(member)
-				})
+				}
 
 				if (withTeam.length > 0) {
 					$("#members").hide()
@@ -64,7 +66,7 @@ $(() => {
 			})
 			.catch(err => {
 				//Email doesn't exist
-				errorHandler(email + " is not a user!")
+				errorHandler(curEmail + " is not a user!")
 			})
 	})
 

--- a/public/js/admin-team-creation.js
+++ b/public/js/admin-team-creation.js
@@ -53,6 +53,12 @@ $(() => {
 										try {
 											member.hasTeam = true
 											member.teamNumber = teamNumber
+											member.teammates = []
+											memberEmails.forEach(e => {
+												if (e !== email) {
+													member.teammates.push(e)
+												}
+											})
 											membersProcessed++
 										} catch (err) {
 											return errorHandler(email + " is not a user!", teamNumber)

--- a/public/js/admin-team-creation.js
+++ b/public/js/admin-team-creation.js
@@ -24,7 +24,7 @@ $(() => {
 		let memberEmails = $('textarea[name="members"]')
 			.val()
 			.split("\n")
-		
+
 		let memberPromises = []
 		memberEmails.forEach(email => {
 			memberPromises.push($.get("/api/users/" + email))

--- a/public/js/admin-team-creation.js
+++ b/public/js/admin-team-creation.js
@@ -173,5 +173,5 @@ function successHandler() {
 	$(".container").html("Success! Redirecting you in 3 seconds.")
 	$(this).hide()
 
-	// setTimeout(location.reload.bind(location), 3000)
+	setTimeout(location.reload.bind(location), 3000)
 }

--- a/public/js/admin-team-creation.js
+++ b/public/js/admin-team-creation.js
@@ -103,7 +103,7 @@ $(() => {
 						.then(teammateData => {
 							let toRemove = teammateData.teammates.indexOf(userEmail)
 							if (toRemove > -1) {
-								teammateData.teammates = teammateData.teammates.splice(toRemove, 1)
+								teammateData.teammates.splice(toRemove, 1)
 							}
 							teammateUpdatePromises.push(
 								$.ajax({

--- a/public/js/admin-team-creation.js
+++ b/public/js/admin-team-creation.js
@@ -79,31 +79,6 @@ $(() => {
 					return errorHandler(email + " is not a user!", teamNumber)
 				})
 		})
-
-		// $.ajax({ url: "/api/teams", type: "PUT", data: team })
-		// 	.then(() => {
-		// 		//For each member of the team, add the team number to the database
-		// 		memberEmails.forEach(email => {
-		// 			$.get("/api/users/" + email)
-		// 				.then(user => {
-		// 					user.hasTeam = true
-		// 					user.teamNumber = teamNumber
-		// 					$.ajax({ url: "/api/users/" + email, type: "PUT", data: user })
-		// 						.catch(err => {
-		// 							return errorHandler(err)
-		// 						})
-		// 					team.
-		// 				})
-		// 				.catch(err => {
-		// 					return errorHandler(err)
-		// 				})
-		// 		})
-		// 		successHandler();
-		// 	})
-		// 	.catch(err => {
-		// 		errorHandler(err)
-		// 	})
-		// })
 	})
 })
 

--- a/views/admin-team-creation.hbs
+++ b/views/admin-team-creation.hbs
@@ -28,7 +28,6 @@
     <link rel='stylesheet' type='text/css' href='/css/form.css' />
     <link rel='stylesheet' type='text/css' href='/css/admin-team-creation.css' />
 
-
     <!-- SCRIPTS -->
     <script src='/js/admin-team-creation.js'></script>
 
@@ -43,7 +42,7 @@
         </div>
 
         <div class="ideahacks-form container text-center">
-            <div id="team-input">
+            <div id="team-number">
                 <p>Enter a new team #</p>
                 <form id="team-submit" onsubmit="return false;">
                     <input class="form-control" type="text" name="team-number" required>
@@ -51,7 +50,7 @@
                 </form>
             </div>
 
-            <div id="users-input" style="display: none;">
+            <div id="members" style="display: none;">
                 <p>Enter member emails</p>
                 <p>Put each email on a new line</p>
                 <form onsubmit="return false;">
@@ -60,6 +59,14 @@
                 </form>
             </div>
 
+            <div id="confirm" style="display: none;">
+                <p>The following members are already in teams:</p>
+                <p id="with-team"></p>
+                <p>Please confirm that they should be removed from their old teams and moved to this new team.</p>
+                <form onsubmit="return false;">
+                    <button type="submit" class="submit-button">Confirm</button>
+                </form>
+            </div>
         </div>
 
 


### PR DESCRIPTION
* Change to only make changes to database once all users are confirmed to exist and final confirmation is given
* Properly update user's `teammates` array when they are added to a team
* If the user is already in a team, request secondary confirmation before moving the user
* On moving a user from an existing team, remove their email from their old teammates' `teammates` array to keep team membership consistent